### PR TITLE
Add some support for Ubuntu 16.04

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -107,6 +107,15 @@ class autossh::install {
 
     /Debian/: {
       package{ $autossh_package: ensure => installed }
+      file{'autossh-tunnel.sh':
+        ensure  => 'present',
+        path    => '/etc/autossh/autossh-tunnel.sh',
+        mode    => '0750',
+        owner   => 'root',
+        group   => 'root',
+        content => template('autossh/autossh.init.systemd.erb'),
+        replace => yes,
+      }
     } # Debian
     
     default: {

--- a/manifests/tunnel.pp
+++ b/manifests/tunnel.pp
@@ -126,6 +126,23 @@ define autossh::tunnel(
         }
       }
     } # case Redhat
+    /Debian/: {
+      case $::operatingsystemmajrelease {
+        /16.04/: {
+          file{"systemd-service-${tun_name}":
+            ensure  => 'present',
+            path    => "/etc/systemd/system/autossh-${tun_name}.service",
+            mode    => '0750',
+            owner   => 'root',
+            group   => 'root',
+            content => template('autossh/autossh.service.erb'),
+            notify  => Service["autossh-${tun_name}"],
+          }
+        }
+        default: {
+        }
+      }
+    }  
 
     default: {
     } # default


### PR DESCRIPTION
I added some support for Ubuntu 16.04. I only worried about the files that I needed so far so the support is most likely not complete, but there is enough working to deploy SSH tunnels using this and puppet on Ubuntu 16.04