### PR TITLE
Allow creating tunnel bits from class args

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,9 +1,9 @@
 # == Class: autossh
 #
 # The autossh service configures persistent 'ssh port forwards' or 'ssh tunnels'
-# between two nodes.  This class caters for both sides of the link from the 
-# 'origin' node which starts the ssh tunnel to the 'endpoint' node which 
-# terminates that tunnel.  There is a base assumption that both nodes connect 
+# between two nodes.  This class caters for both sides of the link from the
+# 'origin' node which starts the ssh tunnel to the 'endpoint' node which
+# terminates that tunnel.  There is a base assumption that both nodes connect
 # to the same puppetdb.
 #
 # === Parameters
@@ -14,11 +14,11 @@
 # $autossh_package = The autossh package name
 # $init_template   = Template to use for the init script
 # $enable          = Enable/Disable package support
-# $pubkey          = Public key to use for tunnels.  If supplied at this level 
+# $pubkey          = Public key to use for tunnels.  If supplied at this level
 #                    is used as the default for all tunnels.
 # $enable          = enable/disable the tunnel
-# $ssh_reuse_established_connections  =  $enable_ssh_reuse: default enable 
-#                   reuse of already established ssh connections, if any. 
+# $ssh_reuse_established_connections  =  $enable_ssh_reuse: default enable
+#                   reuse of already established ssh connections, if any.
 #                   Requires openssh > 5.5.
 # $ssh_enable_compression = enable/disable compression
 # $ssh_ciphers      = set chiper path from lest to most expensive
@@ -54,6 +54,19 @@ class autossh(
   $ssh_ciphers = $autossh::params::ssh_ciphers,
   $ssh_stricthostkeychecking = $autossh::params::ssh_stricthostkeychecking,
   $ssh_tcpkeepalives = $autossh::params::ssh_tcpkeepalives,
+  $tunnels = $autossh::params::tunnels,
+  $endpoints = $autossh::params::endpoints,
+  $tunnel_endpoints = $autossh::params::tunnel_endpoints,
 ) inherits autossh::params {
   include ::autossh::install
+
+  if $tunnels {
+    create_resources('autossh::tunnel', $tunnels)
+  }
+  if $endpoints {
+    create_resources('autossh::endpoint', $endpoints)
+  }
+  if $tunnel_endpoints {
+    create_resources('autossh::tunnel_endpoint', $tunnel_endpoints)
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,7 @@
 # == Class: autossh::params
 #
 # This class defines the default values used in the autossh class.
-# 
+#
 # === Parameters
 #
 # === Variables
@@ -18,9 +18,9 @@
 # $forward_host: default host to forward requests to
 # $bind: the local address to bind to
 # $monitor_port: 0 default monitoring port number for autossh
-# $ssh_reuse_established_connections: default enable reuse of already 
+# $ssh_reuse_established_connections: default enable reuse of already
 #              established ssh connections, if any.  Requires ssh > 5.5.
-# $ssh_compression: enable/disable ssh compression 
+# $ssh_compression: enable/disable ssh compression
 # $ssh_ciphers: cipher selection ordering.  (fastest -> slowest)
 # $ssh_stricthostkeychecking: enable/disable strict host key checking
 # $ssh_tcpkeepalives: enable/disable tcp keepalives
@@ -51,12 +51,15 @@ class autossh::params {
   $forward_host     = 'localhost'
   $monitor_port     = '0'
   $ssh_reuse_established_connections = false  ## Requires openssh > v5.5
-  $ssh_enable_compression = false ## Not really useful for local connections 
+  $ssh_enable_compression = false ## Not really useful for local connections
   $ssh_ciphers =
     'blowfish-cbc,aes128-cbc,3des-cbc,cast128-cbc,arcfour,aes192-cbc,aes256-cbc,aes128-ctr,aes192-ctr,aes256-ctr'
   $ssh_stricthostkeychecking = false
   $ssh_tcpkeepalives = true
 
+  $tunnels = {}
+  $endpoints = {}
+  $tunnel_endpoints = {}
 
   case $::osfamily {
     /RedHat/: {
@@ -74,7 +77,7 @@ class autossh::params {
         default: {
           fail("Error - Unsupported OS Version: ${::operatingsystemrelease}")
         }
-      } # $::operatingsystemmajrelease  
+      } # $::operatingsystemmajrelease
     } # RedHat
 
     /Debian/: {


### PR DESCRIPTION
This permits creating tunnels via class args to init.pp primarily for ENC users.

My vim plugin to remove trailing ending spaces also kicked in a few bits...